### PR TITLE
Fix six weeks

### DIFF
--- a/src/components/DisplayStockOverview/DisplayStockOverview.tsx
+++ b/src/components/DisplayStockOverview/DisplayStockOverview.tsx
@@ -11,8 +11,6 @@ export default function DisplayStockOverview() {
     changePercent = "",
   } = recentlySeenStocks[0].stockOverview || {};
   const isNegativeChange = +changePercent < 0;
-  console.log(recentlySeenStocks);
-
   return (
     <section className="stock_overview_container">
       <div className="logo_symbol_container">

--- a/src/helpers/organizedStocksInGroups.ts
+++ b/src/helpers/organizedStocksInGroups.ts
@@ -24,10 +24,12 @@ export default function organizeStocksInGroups(
       date: timePeriodLabel,
     });
 
-    if (Object.keys(stockDataByGroup).length >= maxNumberOfGroups + 1) {
+    if (Object.keys(stockDataByGroup).length >= maxNumberOfGroups) {
       break;
     }
   }
 
-  return Object.values(stockDataByGroup).filter((group) => group.length >= 2);
+  console.log(stockDataByGroup);
+
+  return Object.values(stockDataByGroup).filter((group) => group);
 }

--- a/src/helpers/organizedStocksInGroups.ts
+++ b/src/helpers/organizedStocksInGroups.ts
@@ -29,7 +29,5 @@ export default function organizeStocksInGroups(
     }
   }
 
-  console.log(stockDataByGroup);
-
   return Object.values(stockDataByGroup).filter((group) => group);
 }


### PR DESCRIPTION
Adjust the length of stock groups when displaying data for either six weeks or five months of stocks.